### PR TITLE
undefined xdr fix when aborting

### DIFF
--- a/jquery.iecors.js
+++ b/jquery.iecors.js
@@ -14,11 +14,10 @@
   if ( jQuery.support.iecors ) {
 
     jQuery.ajaxTransport(function( s ) {
-      var callback;
+      var callback, xdr = s.xdr();
 
       return {
         send: function( headers, complete ) {
-          var xdr = s.xdr();
 
           xdr.onload = function() {
             var headers = { 'Content-Type': xdr.contentType };


### PR DESCRIPTION
on IE8, I abort all requests between a Backbone.View and another, and I am getting xdr undefined, in the abort function
